### PR TITLE
Enable and disable a connection

### DIFF
--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -160,18 +160,22 @@ fn test_enable_disable_functions() {
     assert!(connection.state == ConnectionState::Activated ||
             connection.state == ConnectionState::Deactivated);
 
-    if connection.state == ConnectionState::Activated {
-        disable(&mut connection, 10).unwrap();
-        assert_eq!(ConnectionState::Deactivated, connection.state);
+    match connection.state {
+        ConnectionState::Activated => {
+            disable(&mut connection, 10).unwrap();
+            assert_eq!(ConnectionState::Deactivated, connection.state);
 
-        enable(&mut connection, 10).unwrap();
-        assert_eq!(ConnectionState::Activated, connection.state);
-    } else {
-        enable(&mut connection, 10).unwrap();
-        assert_eq!(ConnectionState::Activated, connection.state);
+            enable(&mut connection, 10).unwrap();
+            assert_eq!(ConnectionState::Activated, connection.state);
+        }
+        ConnectionState::Deactivated => {
+            enable(&mut connection, 10).unwrap();
+            assert_eq!(ConnectionState::Activated, connection.state);
 
-        disable(&mut connection, 10).unwrap();
-        assert_eq!(ConnectionState::Deactivated, connection.state);
+            disable(&mut connection, 10).unwrap();
+            assert_eq!(ConnectionState::Deactivated, connection.state);
+        }
+        _ => (),
     }
 }
 

--- a/src/dbus_helper/mod.rs
+++ b/src/dbus_helper/mod.rs
@@ -14,7 +14,6 @@ macro_rules! dbus_property {
 
         dbus::Props::new(&connection, $service, $path, $interface, 2000).
             get($property)
-            // .unwrap_or_else(|e| panic!("dbus_property error: {}", e))
     }}
 }
 

--- a/src/dbus_helper/mod.rs
+++ b/src/dbus_helper/mod.rs
@@ -3,21 +3,26 @@ extern crate dbus;
 macro_rules! dbus_message {
     ($service:expr, $path:expr, $interface:expr, $function:expr) => {{
        dbus::Message::new_method_call($service, $path, $interface, $function).
-           unwrap()
+           unwrap_or_else(|e| panic!("dbus_message error: {}", e))
     }}
 }
 
 macro_rules! dbus_property {
    ($service:expr, $path:expr, $interface:expr, $property:expr) => {{
-        let connection = dbus::Connection::get_private(dbus::BusType::System).unwrap();
+        let connection = dbus::Connection::get_private(dbus::BusType::System)
+            .unwrap_or_else(|e| panic!("dbus_property error: {}", e));
+
         dbus::Props::new(&connection, $service, $path, $interface, 2000).
             get($property)
+            // .unwrap_or_else(|e| panic!("dbus_property error: {}", e))
     }}
 }
 
 macro_rules! dbus_connect {
     ($message:expr) => {{
-        dbus::Connection::get_private(dbus::BusType::System).unwrap().
+        dbus::Connection::get_private(dbus::BusType::System)
+            .unwrap_or_else(|e| panic!("dbus_connect error: {}", e)).
             send_with_reply_and_block($message, 2000)
+            .unwrap_or_else(|e| panic!("dbus_connect error: {}", e))
     }}
 }

--- a/src/dbus_helper/mod.rs
+++ b/src/dbus_helper/mod.rs
@@ -11,7 +11,7 @@ macro_rules! dbus_property {
    ($service:expr, $path:expr, $interface:expr, $property:expr) => {{
         let connection = dbus::Connection::get_private(dbus::BusType::System).unwrap();
         dbus::Props::new(&connection, $service, $path, $interface, 2000).
-            get($property).unwrap()
+            get($property)
     }}
 }
 

--- a/src/general/mod.rs
+++ b/src/general/mod.rs
@@ -50,6 +50,7 @@ pub fn status() -> Result<Status, String> {
                                                      NM_SERVICE_PATH,
                                                      NM_SERVICE_INTERFACE,
                                                      "WirelessEnabled")
+        .unwrap()
         .inner()
         .unwrap();
 
@@ -57,6 +58,7 @@ pub fn status() -> Result<Status, String> {
                                                NM_SERVICE_PATH,
                                                NM_SERVICE_INTERFACE,
                                                "NetworkingEnabled")
+        .unwrap()
         .inner()
         .unwrap();
 
@@ -136,8 +138,7 @@ pub enum NetworkManagerState {
 }
 }
 
-#[derive(Debug)]
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum ServiceState {
     Active,
     Reloading,
@@ -164,7 +165,7 @@ impl FromStr for ServiceState {
 }
 
 enum_from_primitive!{
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ConnectionState {
     Unknown = 0,
     Activating = 1,

--- a/src/general/mod.rs
+++ b/src/general/mod.rs
@@ -65,6 +65,7 @@ pub fn status() -> Result<Status, String> {
     Ok(status)
 }
 
+// This should be implemented as a trait in the dbus crate
 pub fn dbus_path_to_string(path: dbus::Path) -> String {
     path.as_cstr().to_str().unwrap().to_string()
 }
@@ -165,7 +166,7 @@ impl FromStr for ServiceState {
 }
 
 enum_from_primitive!{
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum ConnectionState {
     Unknown = 0,
     Activating = 1,

--- a/src/general/mod.rs
+++ b/src/general/mod.rs
@@ -23,8 +23,9 @@ pub const SD_UNIT_INTERFACE: &'static str = "org.freedesktop.systemd1.Unit";
 ///
 /// # Examples
 ///
-/// ```
-/// let status = network_manager::general::status().unwrap();
+/// ```no_run
+/// use network_manager::general;
+/// let status = general::status().unwrap();
 /// println!("{:?}", status);
 /// ```
 pub fn status() -> Result<Status, String> {
@@ -34,7 +35,7 @@ pub fn status() -> Result<Status, String> {
                                 NM_SERVICE_PATH,
                                 NM_SERVICE_INTERFACE,
                                 "state");
-    let response = dbus_connect!(message).unwrap();
+    let response = dbus_connect!(message);
     let val: u32 = response.get1().unwrap();
     status.state = NetworkManagerState::from(val);
 
@@ -42,7 +43,7 @@ pub fn status() -> Result<Status, String> {
                                 NM_SERVICE_PATH,
                                 NM_SERVICE_INTERFACE,
                                 "CheckConnectivity");
-    let response = dbus_connect!(message).unwrap();
+    let response = dbus_connect!(message);
     let val: u32 = response.get1().unwrap();
     status.connectivity = Connectivity::from(val);
 
@@ -68,42 +69,6 @@ pub fn status() -> Result<Status, String> {
 // This should be implemented as a trait in the dbus crate
 pub fn dbus_path_to_string(path: dbus::Path) -> String {
     path.as_cstr().to_str().unwrap().to_string()
-}
-
-impl From<u32> for NetworkManagerState {
-    fn from(val: u32) -> NetworkManagerState {
-        NetworkManagerState::from_u32(val).expect("Invalid Network Manager State enum value")
-    }
-}
-
-impl From<NetworkManagerState> for u32 {
-    fn from(val: NetworkManagerState) -> u32 {
-        val as u32
-    }
-}
-
-impl From<u32> for Connectivity {
-    fn from(val: u32) -> Connectivity {
-        Connectivity::from_u32(val).expect("Invalid Connectivity enum value")
-    }
-}
-
-impl From<Connectivity> for u32 {
-    fn from(val: Connectivity) -> u32 {
-        val as u32
-    }
-}
-
-impl From<u32> for ConnectionState {
-    fn from(val: u32) -> ConnectionState {
-        ConnectionState::from_u32(val).expect("Invalid ConnectionState enum value")
-    }
-}
-
-impl From<ConnectionState> for u32 {
-    fn from(val: ConnectionState) -> u32 {
-        val as u32
-    }
 }
 
 #[derive(Debug)]
@@ -137,6 +102,18 @@ pub enum NetworkManagerState {
     ConnectedSite = 60,
     ConnectedGlobal = 70,
 }
+}
+
+impl From<u32> for NetworkManagerState {
+    fn from(val: u32) -> NetworkManagerState {
+        NetworkManagerState::from_u32(val).expect("Invalid Network Manager State enum value")
+    }
+}
+
+impl From<NetworkManagerState> for u32 {
+    fn from(val: NetworkManagerState) -> u32 {
+        val as u32
+    }
 }
 
 #[derive(Debug, PartialEq)]
@@ -176,6 +153,18 @@ pub enum ConnectionState {
 }
 }
 
+impl From<u32> for ConnectionState {
+    fn from(val: u32) -> ConnectionState {
+        ConnectionState::from_u32(val).expect("Invalid ConnectionState enum value")
+    }
+}
+
+impl From<ConnectionState> for u32 {
+    fn from(val: ConnectionState) -> u32 {
+        val as u32
+    }
+}
+
 #[derive(Debug)]
 pub enum DeviceState {
     Unknown,
@@ -196,6 +185,18 @@ pub enum Connectivity { // See https://bugzilla.gnome.org/show_bug.cgi?id=776848
     Limited = 3,
     Full = 4,
 }
+}
+
+impl From<u32> for Connectivity {
+    fn from(val: u32) -> Connectivity {
+        Connectivity::from_u32(val).expect("Invalid Connectivity enum value")
+    }
+}
+
+impl From<Connectivity> for u32 {
+    fn from(val: Connectivity) -> u32 {
+        val as u32
+    }
 }
 
 #[derive(Debug)]

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -7,56 +7,88 @@ use general::*;
 ///
 /// # Examples
 ///
-/// ```
-/// # network_manager::service::disable(10);
-/// let state = network_manager::service::enable(10).unwrap();
+/// ```no_run
+/// use network_manager::service;
+/// let state = service::enable(10).unwrap();
 /// println!("{:?}", state);
 /// ```
 pub fn enable(time_out: i32) -> Result<ServiceState, String> {
-    if state().unwrap() == ServiceState::Active {
-        return Ok(ServiceState::Active);
+    match state().expect("Unable to get service state") {
+        ServiceState::Active => Ok(ServiceState::Active),
+        ServiceState::Activating => wait(time_out, ServiceState::Active),
+        ServiceState::Failed => Err("Service has failed".to_string()),
+        _ => {
+            let mut message = dbus_message!(SD_SERVICE_MANAGER,
+                                            SD_SERVICE_PATH,
+                                            SD_MANAGER_INTERFACE,
+                                            "StartUnit");
+            message.append_items(&["NetworkManager.service".into(), "fail".into()]);
+            dbus_connect!(message);
+
+            wait(time_out, ServiceState::Active)
+        }
     }
-
-    let mut message = dbus_message!(SD_SERVICE_MANAGER,
-                                    SD_SERVICE_PATH,
-                                    SD_MANAGER_INTERFACE,
-                                    "StartUnit");
-    message.append_items(&["NetworkManager.service".into(), "fail".into()]);
-    dbus_connect!(message).unwrap();
-
-    wait(time_out, ServiceState::Active)
 }
 
 /// Disables the Network Manager service.
 ///
 /// # Examples
 ///
-/// ```
-/// # network_manager::service::enable(10);
-/// let state = network_manager::service::disable(10).unwrap();
+/// ```no_run
+/// use network_manager::service;
+/// let state = service::disable(10).unwrap();
 /// println!("{:?}", state);
 /// ```
 pub fn disable(time_out: i32) -> Result<ServiceState, String> {
-    if state().unwrap() == ServiceState::Inactive {
-        return Ok(ServiceState::Inactive);
+    match state().expect("Unable to get service state") {
+        ServiceState::Inactive => Ok(ServiceState::Inactive),
+        ServiceState::Deactivating => wait(time_out, ServiceState::Inactive),
+        ServiceState::Failed => Err("Service has failed".to_string()),
+        _ => {
+            let mut message = dbus_message!(SD_SERVICE_MANAGER,
+                                            SD_SERVICE_PATH,
+                                            SD_MANAGER_INTERFACE,
+                                            "StopUnit");
+            message.append_items(&["NetworkManager.service".into(), "fail".into()]);
+            dbus_connect!(message);
+
+            wait(time_out, ServiceState::Inactive)
+        }
     }
+}
 
-    let mut message = dbus_message!(SD_SERVICE_MANAGER,
-                                    SD_SERVICE_PATH,
-                                    SD_MANAGER_INTERFACE,
-                                    "StopUnit");
-    message.append_items(&["NetworkManager.service".into(), "fail".into()]);
-    dbus_connect!(message).unwrap();
+#[test]
+fn test_enable_disable_functions() {
+    let s = state().unwrap();
 
-    wait(time_out, ServiceState::Inactive)
+    assert!(s == ServiceState::Active || s == ServiceState::Inactive);
+
+    match s {
+        ServiceState::Active => {
+            disable(10).unwrap();
+            assert_eq!(ServiceState::Inactive, state().unwrap());
+
+            enable(10).unwrap();
+            assert_eq!(ServiceState::Active, state().unwrap());
+        }
+        ServiceState::Inactive => {
+            enable(10).unwrap();
+            assert_eq!(ServiceState::Active, state().unwrap());
+
+            disable(10).unwrap();
+            assert_eq!(ServiceState::Inactive, state().unwrap());
+        }
+        _ => (),
+    }
 }
 
 /// Gets the state of the Network Manager service.
 ///
 /// # Examples
 ///
-/// ```
-/// let state = network_manager::service::state().unwrap();
+/// ```no_run
+/// use network_manager::service;
+/// let state = service::state().unwrap();
 /// println!("{:?}", state);
 /// ```
 pub fn state() -> Result<ServiceState, String> {
@@ -65,7 +97,7 @@ pub fn state() -> Result<ServiceState, String> {
                                     SD_MANAGER_INTERFACE,
                                     "GetUnit");
     message.append_items(&["NetworkManager.service".into()]);
-    let response = dbus_connect!(message).unwrap();
+    let response = dbus_connect!(message);
     let unit_path: dbus::Path = response.get1().unwrap();
 
     let state: ServiceState = dbus_property!(SD_SERVICE_MANAGER,
@@ -92,7 +124,7 @@ fn wait(time_out: i32, target_state: ServiceState) -> Result<ServiceState, Strin
             return state();
         }
         std::thread::sleep(std::time::Duration::from_secs(1));
-        total_time = total_time + 1;
+        total_time += 1;
     }
 
     Err("service timed out".to_string())

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -72,6 +72,7 @@ pub fn state() -> Result<ServiceState, String> {
                                              unit_path,
                                              SD_UNIT_INTERFACE,
                                              "ActiveState")
+        .unwrap()
         .inner::<&String>()
         .unwrap()
         .parse()


### PR DESCRIPTION
Fixes #5
Fixes #6

All public functions have examples, `no_run` means that the example will be compiled but not run.
All public functions have an explicit test, tests should be run with `RUST_TEST_THREADS=1 sudo cargo test` to ensure the tests are run sequentially.