### PR TITLE
Isolating dbus-rs usage and connection fixes

### DIFF
--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -40,7 +40,6 @@ fn test_list_function() {
 
     for (index, val) in connections.iter().enumerate() {
         assert_ne!(Connection { ..Default::default() }, val.clone());
-        assert_eq!(index as i32, i32::from(val));
     }
 }
 

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -4,6 +4,7 @@ use std;
 use std::env;
 use general::*;
 use device::DeviceType;
+use manager;
 use manager::NetworkManager;
 
 /// Get a list of Network Manager connections sorted by path.
@@ -12,8 +13,8 @@ use manager::NetworkManager;
 ///
 /// ```no_run
 /// use network_manager::connection;
-/// use network_manager::manager::NetworkManager;
-/// let manager = NetworkManager::new();
+/// use network_manager::manager;
+/// let manager = manager::new();
 /// let connections = connection::list(&manager).unwrap();
 /// println!("{:?}", connections);
 /// ```
@@ -33,7 +34,7 @@ pub fn list(manager: &NetworkManager) -> Result<Vec<Connection>, String> {
 
 #[test]
 fn test_list_function() {
-    let manager = NetworkManager::new();
+    let manager = manager::new();
 
     let connections = list(&manager).unwrap();
     assert!(connections.len() > 0);
@@ -86,17 +87,13 @@ pub fn create(s: &str, dt: DeviceType, sc: Security, p: &str) -> Result<Connecti
 ///
 /// ```
 /// use network_manager::connection;
-/// use network_manager::manager::NetworkManager;
-/// let manager = NetworkManager::new();
+/// use network_manager::manager;
+/// let manager = manager::new();
 /// let mut connections = connection::list(&manager).unwrap();
-/// connection::delete(connections.pop().unwrap()).unwrap();
+/// connection::delete(&manager, connections.pop().unwrap()).unwrap();
 /// ```
-pub fn delete(connection: Connection) -> Result<(), String> {
-    let message = dbus_message!(NM_SERVICE_MANAGER,
-                                connection.path,
-                                NM_CONNECTION_INTERFACE,
-                                "Delete");
-    dbus_connect!(message);
+pub fn delete(manager: &NetworkManager, connection: Connection) -> Result<(), String> {
+    try!(manager.delete_connection(&connection.path));
 
     Ok(())
 }
@@ -107,8 +104,8 @@ pub fn delete(connection: Connection) -> Result<(), String> {
 ///
 /// ```no_run
 /// use network_manager::connection;
-/// use network_manager::manager::NetworkManager;
-/// let manager = NetworkManager::new();
+/// use network_manager::manager;
+/// let manager = manager::new();
 /// let connections = connection::list(&manager).unwrap();
 /// let mut connection = connections[0].clone();
 /// connection::enable(&manager, &mut connection, 10).unwrap();
@@ -148,8 +145,8 @@ pub fn enable(manager: &NetworkManager,
 ///
 /// ```no_run
 /// use network_manager::connection;
-/// use network_manager::manager::NetworkManager;
-/// let manager = NetworkManager::new();
+/// use network_manager::manager;
+/// let manager = manager::new();
 /// let connections = connection::list(&manager).unwrap();
 /// let mut connection = connections[0].clone();
 /// connection::disable(&manager, &mut connection, 10).unwrap();
@@ -183,7 +180,7 @@ pub fn disable(manager: &NetworkManager,
 
 #[test]
 fn test_enable_disable_functions() {
-    let manager = NetworkManager::new();
+    let manager = manager::new();
 
     let connections = list(&manager).unwrap();
     let mut connection;

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -1,6 +1,7 @@
 extern crate dbus;
 
 use std;
+use std::env;
 use general::*;
 use device::DeviceType;
 use manager::NetworkManager;
@@ -11,7 +12,8 @@ use manager::NetworkManager;
 ///
 /// ```no_run
 /// use network_manager::connection;
-/// let manager = network_manager::manager::NetworkManager::new();
+/// use network_manager::manager::NetworkManager;
+/// let manager = NetworkManager::new();
 /// let connections = connection::list(&manager).unwrap();
 /// println!("{:?}", connections);
 /// ```
@@ -84,9 +86,11 @@ pub fn create(s: &str, dt: DeviceType, sc: Security, p: &str) -> Result<Connecti
 /// # Examples
 ///
 /// ```
-/// let manager = network_manager::manager::NetworkManager::new();
-/// let mut connections = network_manager::connection::list(&manager).unwrap();
-/// network_manager::connection::delete(connections.pop().unwrap()).unwrap();
+/// use network_manager::connection;
+/// use network_manager::manager::NetworkManager;
+/// let manager = NetworkManager::new();
+/// let mut connections = connection::list(&manager).unwrap();
+/// connection::delete(connections.pop().unwrap()).unwrap();
 /// ```
 pub fn delete(connection: Connection) -> Result<(), String> {
     let message = dbus_message!(NM_SERVICE_MANAGER,
@@ -104,7 +108,8 @@ pub fn delete(connection: Connection) -> Result<(), String> {
 ///
 /// ```no_run
 /// use network_manager::connection;
-/// let manager = network_manager::manager::NetworkManager::new();
+/// use network_manager::manager::NetworkManager;
+/// let manager = NetworkManager::new();
 /// let connections = connection::list(&manager).unwrap();
 /// let mut connection = connections[0].clone();
 /// connection::enable(&manager, &mut connection, 10).unwrap();
@@ -144,7 +149,8 @@ pub fn enable(manager: &NetworkManager,
 ///
 /// ```no_run
 /// use network_manager::connection;
-/// let manager = network_manager::manager::NetworkManager::new();
+/// use network_manager::manager::NetworkManager;
+/// let manager = NetworkManager::new();
 /// let connections = connection::list(&manager).unwrap();
 /// let mut connection = connections[0].clone();
 /// connection::disable(&manager, &mut connection, 10).unwrap();

--- a/src/general/mod.rs
+++ b/src/general/mod.rs
@@ -1,7 +1,6 @@
 extern crate dbus;
 extern crate enum_primitive;
 
-use std::str::FromStr;
 use enum_primitive::FromPrimitive;
 
 pub const NM_SERVICE_MANAGER: &'static str = "org.freedesktop.NetworkManager";
@@ -65,10 +64,7 @@ pub fn status() -> Result<Status, String> {
 
 // This should be implemented as a trait in the dbus crate
 pub fn dbus_path_to_string(path: dbus::Path) -> String {
-    path.as_cstr()
-        .to_str()
-        .unwrap()
-        .to_string()
+    path.as_cstr().to_str().unwrap().to_string()
 }
 
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,3 +18,4 @@ pub mod wifi;
 pub mod service;
 pub mod connection;
 pub mod device;
+pub mod manager;

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -9,6 +9,11 @@ use connection::ConnectionSettings;
 use general::*;
 
 
+pub fn new() -> NetworkManager {
+    NetworkManager::new()
+}
+
+
 pub struct NetworkManager {
     connection: DBusConnection,
 }
@@ -84,6 +89,14 @@ impl NetworkManager {
                uuid: uuid,
                ssid: ssid,
            })
+    }
+
+    pub fn delete_connection(&self, path: &String) -> Result<(), String> {
+        let response = try!(self.call(path, NM_CONNECTION_INTERFACE, "Delete"));
+
+        println!("{:?}", response);
+
+        Ok(())
     }
 
     fn call(&self, path: &str, interface: &str, method: &str) -> Result<Message, String> {

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -1,0 +1,248 @@
+use dbus::Connection as DBusConnection;
+use dbus::{BusType, Path, ConnPath, Message};
+use dbus::arg::{Dict, Variant, Iter, Array, Get, RefArg};
+use dbus::stdintf::OrgFreedesktopDBusProperties;
+
+use enum_primitive::FromPrimitive;
+
+use connection::ConnectionSettings;
+use general::*;
+
+
+pub struct NetworkManager {
+    connection: DBusConnection,
+}
+
+
+impl NetworkManager {
+    pub fn new() -> Self {
+        let connection = DBusConnection::get_private(BusType::System).unwrap();
+
+        NetworkManager { connection: connection }
+
+    }
+
+    pub fn list_connections(&self) -> Result<Vec<String>, String> {
+        let response = try!(self.call(NM_SETTINGS_PATH, NM_SETTINGS_INTERFACE, "ListConnections"));
+
+        let array: Array<Path, _> = try!(self.extract(&response));
+
+        Ok(array.map(|e| e.to_string()).collect())
+    }
+
+    pub fn get_active_connections(&self) -> Result<Vec<String>, String> {
+        self.property(NM_SERVICE_PATH, NM_SERVICE_INTERFACE, "ActiveConnections")
+    }
+
+    pub fn get_active_connection_path(&self, path: &String) -> Option<String> {
+        match self.property(path, NM_ACTIVE_INTERFACE, "Connection") {
+            Ok(p) => Some(p),
+            Err(_) => None,
+        }
+    }
+
+    pub fn get_connection_state(&self, path: &String) -> Result<ConnectionState, String> {
+        let state_i64 = match self.property(path, NM_ACTIVE_INTERFACE, "State") {
+            Ok(state_i64) => state_i64,
+            Err(_) => return Ok(ConnectionState::Unknown),
+        };
+
+        match ConnectionState::from_i64(state_i64) {
+            Some(state) => Ok(state),
+            None => Err(format!("Undefined connection state for {}", path)),
+        }
+    }
+
+    pub fn get_connection_settings(&self, path: &String) -> Result<ConnectionSettings, String> {
+        let response = try!(self.call(&path, NM_CONNECTION_INTERFACE, "GetSettings"));
+
+        let dict: Dict<&str, Dict<&str, Variant<Iter>, _>, _> = try!(self.extract(&response));
+
+        let mut id = String::new();
+        let mut uuid = String::new();
+        let mut ssid = String::new();
+
+        for (_, v1) in dict {
+            for (k2, v2) in v1 {
+                match k2 {
+                    "id" => {
+                        id = try!(extract::<String>(&v2));
+                    }
+                    "uuid" => {
+                        uuid = try!(extract::<String>(&v2));
+                    }
+                    "ssid" => {
+                        ssid = try!(utf8_variant_to_string(&v2));
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        Ok(ConnectionSettings {
+               id: id,
+               uuid: uuid,
+               ssid: ssid,
+           })
+    }
+
+    fn call(&self, path: &str, interface: &str, method: &str) -> Result<Message, String> {
+        let call_error = |details: &str| {
+            Err(format!("D-Bus '{}'::'{}' method call failed on '{}': {}",
+                        interface,
+                        method,
+                        path,
+                        details))
+        };
+
+        match Message::new_method_call(NM_SERVICE_MANAGER, path, interface, method) {
+            Ok(message) => {
+                match self.connection.send_with_reply_and_block(message, 2000) {
+                    Ok(response) => Ok(response),
+                    Err(err) => {
+                        match err.message() {
+                            Some(details) => call_error(details),
+                            None => call_error("no details"),
+                        }
+                    }
+                }
+            }
+            Err(details) => call_error(&details),
+        }
+    }
+
+    fn extract<'a, T>(&self, response: &'a Message) -> Result<T, String>
+        where T: Get<'a>
+    {
+        match response.get1() {
+            Some(data) => Ok(data),
+            None => Err("D-Bus wrong response type".to_string()),
+        }
+    }
+
+    fn with_path<'a, P: Into<Path<'a>>>(&'a self, path: P) -> ConnPath<'a, &'a DBusConnection> {
+        self.connection.with_path(NM_SERVICE_MANAGER, path, 2000)
+    }
+}
+
+
+trait Property<T> {
+    fn property(&self, path: &str, interface: &str, name: &str) -> Result<T, String>;
+}
+
+
+impl<T> Property<T> for NetworkManager
+    where NetworkManager: VariantTo<T>
+{
+    fn property(&self, path: &str, interface: &str, name: &str) -> Result<T, String> {
+        let property_error = |details: &str| {
+            Err(format!("D-Bus get '{}'::'{}' property failed on '{}': {}",
+                        interface,
+                        name,
+                        path,
+                        details))
+        };
+
+        let path = self.with_path(path);
+
+        match path.get(interface, name) {
+            Ok(variant) => {
+                match NetworkManager::variant_to(variant) {
+                    Some(data) => Ok(data),
+                    None => property_error("wrong property type"),
+                }
+            }
+            Err(err) => {
+                match err.message() {
+                    Some(details) => property_error(details),
+                    None => property_error("no details"),
+                }
+            }
+        }
+    }
+}
+
+
+trait VariantTo<T> {
+    fn variant_to(value: Variant<Box<RefArg>>) -> Option<T>;
+}
+
+
+impl VariantTo<String> for NetworkManager {
+    fn variant_to(value: Variant<Box<RefArg>>) -> Option<String> {
+        variant_to_string(value)
+    }
+}
+
+
+impl VariantTo<i64> for NetworkManager {
+    fn variant_to(value: Variant<Box<RefArg>>) -> Option<i64> {
+        variant_to_i64(value)
+    }
+}
+
+
+impl VariantTo<Vec<String>> for NetworkManager {
+    fn variant_to(value: Variant<Box<RefArg>>) -> Option<Vec<String>> {
+        variant_to_string_list(value)
+    }
+}
+
+
+fn variant_to_string_list(value: Variant<Box<RefArg>>) -> Option<Vec<String>> {
+    let mut result = Vec::new();
+
+    if let Some(list) = value.0.as_iter() {
+        for element in list {
+            if let Some(string) = element.as_str() {
+                result.push(string.to_string());
+            } else {
+                return None;
+            }
+        }
+
+        Some(result)
+    } else {
+        None
+    }
+}
+
+
+fn variant_to_string(value: Variant<Box<RefArg>>) -> Option<String> {
+    if let Some(string) = value.0.as_str() {
+        Some(string.to_string())
+    } else {
+        None
+    }
+}
+
+
+fn variant_to_i64(value: Variant<Box<RefArg>>) -> Option<i64> {
+    value.0.as_i64()
+}
+
+
+fn extract<'a, T>(var: &'a Variant<Iter>) -> Result<T, String>
+    where T: Get<'a>
+{
+    match var.0.clone().get::<T>() {
+        Some(value) => Ok(value),
+        None => Err(format!("D-Bus variant type does not match: {:?}", var)),
+    }
+}
+
+
+fn utf8_variant_to_string(var: &Variant<Iter>) -> Result<String, String> {
+    let array_option = &var.0.clone().get::<Array<u8, _>>();
+
+    if let Some(array) = *array_option {
+        let utf8_vec = array.collect::<Vec<u8>>();
+
+        match ::std::str::from_utf8(&utf8_vec) {
+            Ok(string) => Ok(string.to_string()),
+            Err(_) => Err(format!("D-Bus variant not a UTF-8 string: {:?}", var)),
+        }
+    } else {
+        Err(format!("D-Bus variant not an array: {:?}", var))
+    }
+}


### PR DESCRIPTION
A new module is introduced with the intention of creating additional facade isolating the usage of dbus-rs. All returned values and arguments of the new module API are standard Rust structs or our own structs. Internally usage of dbus-rs is improved by using different language features. More complete error handling is introduced with the new module.