### PR TITLE
Enable/disable device, create connection and Wi-Fi scan

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ enum_primitive = "0.1.0"
 futures = "0.1.9"
 futures-cpupool = "0.1.2"
 tokio-timer = "0.1.0"
+bitflags = "0.8.0"
 
 [features]
 default = []

--- a/examples/create.rs
+++ b/examples/create.rs
@@ -20,17 +20,18 @@ fn main() {
     let manager = manager::new();
 
     let mut devices = device::list(&manager).unwrap();
-    let i = devices
+    let device_index = devices
         .iter()
         .position(|ref d| d.device_type == device::DeviceType::WiFi)
         .unwrap();
-    let device_ref = &mut devices[i];
+    let device_ref = &mut devices[device_index];
 
     let access_points = wifi::scan(&manager, device_ref).unwrap();
 
-    for access_point in access_points {
-        if access_point.ssid == args[1] {
-            connection::create(&manager, device_ref, &access_point, &args[2], 10).unwrap();
-        }
-    }
+    let ap_index = access_points
+        .iter()
+        .position(|ref ap| ap.ssid == args[1])
+        .unwrap();
+
+    connection::create(&manager, device_ref, &access_points[ap_index], &args[2], 10).unwrap();
 }

--- a/examples/create.rs
+++ b/examples/create.rs
@@ -1,0 +1,36 @@
+extern crate network_manager;
+
+use std::env;
+use std::process;
+
+use network_manager::manager;
+use network_manager::wifi;
+use network_manager::device;
+use network_manager::connection;
+
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() < 3 {
+        println!("USAGE: create SSID PASSWORD");
+        process::exit(1);
+    }
+
+    let manager = manager::new();
+
+    let mut devices = device::list(&manager).unwrap();
+    let i = devices
+        .iter()
+        .position(|ref d| d.device_type == device::DeviceType::WiFi)
+        .unwrap();
+    let device_ref = &mut devices[i];
+
+    let access_points = wifi::scan(&manager, device_ref).unwrap();
+
+    for access_point in access_points {
+        if access_point.ssid == args[1] {
+            connection::create(&manager, device_ref, &access_point, &args[2], 10).unwrap();
+        }
+    }
+}

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -55,7 +55,7 @@ fn test_list_function() {
 /// let connection = network_manager::connection::create(
 ///     "resin_io",
 ///     network_manager::device::DeviceType::WiFi,
-///     network_manager::wifi::Security::WPA2,
+///     network_manager::wifi::WPA2,
 ///     "super_secret_passphase"
 ///     ).unwrap();
 /// println!("{:?}", connection);
@@ -77,7 +77,7 @@ pub fn create(s: &str, dt: DeviceType, sc: Security, p: &str) -> Result<Connecti
         settings: settings,
         state: ConnectionState::Deactivated, /* device: "wlp4s0".to_string(),
                                               * interface: DeviceType::WiFi,
-                                              * security: Security::WPA2,
+                                              * security: WPA2,
                                               * state: ConnectionState::Activated, */
     };
 

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -5,8 +5,8 @@ use std::env;
 
 use enum_primitive::FromPrimitive;
 
-use device::DeviceType;
-use wifi::Security;
+use device::{Device, DeviceType};
+use wifi::{AccessPoint, Security};
 use manager;
 use manager::NetworkManager;
 
@@ -48,40 +48,26 @@ fn test_list_function() {
 }
 
 /// Creates a Network Manager connection.
-///
-/// # Examples
-///
-/// ```
-/// let connection = network_manager::connection::create(
-///     "resin_io",
-///     network_manager::device::DeviceType::WiFi,
-///     network_manager::wifi::WPA2,
-///     "super_secret_passphase"
-///     ).unwrap();
-/// println!("{:?}", connection);
-/// ```
-pub fn create(s: &str, dt: DeviceType, sc: Security, p: &str) -> Result<Connection, String> {
-    // Create a connection
-    // Get the connection
-    // Return the connection
+pub fn create(manager: &NetworkManager,
+              device: &Device,
+              access_point: &AccessPoint,
+              password: &str,
+              time_out: i32)
+              -> Result<Connection, String> {
+    let (path, _) = try!(manager.add_and_activate_connection(&device.path,
+                                                             &access_point.path,
+                                                             &access_point.ssid,
+                                                             &access_point.security,
+                                                             password));
 
-    let settings = ConnectionSettings {
-        id: "resin_io".to_string(),
-        uuid: "3c8e6e8b-b895-4b07-97a5-bbc192c3b436".to_string(),
-        ssid: "resin_io".to_string(),
-    };
+    let mut connection = try!(get_connection(manager, &path));
 
-    let connection1 = Connection {
-        path: "/org/freedesktop/NetworkManager/ActiveConnection/187".to_string(),
-        active_path: "test".to_string(),
-        settings: settings,
-        state: ConnectionState::Deactivated, /* device: "wlp4s0".to_string(),
-                                              * interface: DeviceType::WiFi,
-                                              * security: WPA2,
-                                              * state: ConnectionState::Activated, */
-    };
+    try!(wait(manager,
+              &mut connection,
+              time_out,
+              ConnectionState::Activated));
 
-    Ok(connection1)
+    Ok(connection)
 }
 
 /// Deletes a Network Manager connection.

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -10,7 +10,6 @@ pub struct Device {
     pub path: String,
     pub device_type: DeviceType,
     pub state: DeviceState,
-    pub real: bool,
 }
 
 impl Device {
@@ -21,14 +20,11 @@ impl Device {
 
         let state = try!(manager.get_device_state(&path));
 
-        let real = try!(manager.is_device_real(&path));
-
         Ok(Device {
                interface: interface,
                path: path.clone(),
                device_type: device_type,
                state: state,
-               real: real,
            })
     }
 }
@@ -120,17 +116,17 @@ fn test_list_function() {
 
 /// Connects a Network Manager device.
 ///
-/// # Examples
+/// Examples
 ///
-/// # ```
-/// # use network_manager::device;
-/// # use network_manager::manager;
-/// # let manager = manager::new();
-/// # let mut devices = device::list(&manager).unwrap();
-/// # let i = devices.iter().position(|ref d| d.device_type == device::DeviceType::WiFi).unwrap();
-/// # let device = &mut devices[i];
-/// # device::connect(&manager, device, 10).unwrap();
-/// # ```
+/// ```
+/// use network_manager::device;
+/// use network_manager::manager;
+/// let manager = manager::new();
+/// let mut devices = device::list(&manager).unwrap();
+/// let i = devices.iter().position(|ref d| d.device_type == device::DeviceType::WiFi).unwrap();
+/// let device = &mut devices[i];
+/// device::connect(&manager, device, 10).unwrap();
+/// ```
 pub fn connect(manager: &NetworkManager, device: &mut Device, time_out: i32) -> Result<(), String> {
     match device.state {
         DeviceState::Activated => Ok(()),

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -202,7 +202,10 @@ fn test_connect_disconnect_functions() {
 
     let mut devices = list(&manager).unwrap();
 
-    let i = devices.iter().position(|ref d| d.device_type == DeviceType::WiFi).unwrap();
+    let i = devices
+        .iter()
+        .position(|ref d| d.device_type == DeviceType::WiFi)
+        .unwrap();
     let device = &mut devices[i];
 
     if device.state == DeviceState::Activated {

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -122,15 +122,15 @@ fn test_list_function() {
 ///
 /// # Examples
 ///
-/// ```
-/// use network_manager::device;
-/// use network_manager::manager;
-/// let manager = manager::new();
-/// let mut devices = device::list(&manager).unwrap();
-/// let i = devices.iter().position(|ref d| d.device_type == device::DeviceType::WiFi).unwrap();
-/// let device = &mut devices[i];
-/// device::connect(&manager, device, 10).unwrap();
-/// ```
+/// # ```
+/// # use network_manager::device;
+/// # use network_manager::manager;
+/// # let manager = manager::new();
+/// # let mut devices = device::list(&manager).unwrap();
+/// # let i = devices.iter().position(|ref d| d.device_type == device::DeviceType::WiFi).unwrap();
+/// # let device = &mut devices[i];
+/// # device::connect(&manager, device, 10).unwrap();
+/// # ```
 pub fn connect(manager: &NetworkManager, device: &mut Device, time_out: i32) -> Result<(), String> {
     match device.state {
         DeviceState::Activated => Ok(()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,9 @@
 #[macro_use]
 extern crate enum_primitive;
 
+#[macro_use]
+extern crate bitflags;
+
 extern crate dbus;
 
 pub mod status;

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -430,7 +430,7 @@ fn variant_to_u8_vec(value: Variant<Box<RefArg>>) -> Option<Vec<u8>> {
 
 
 fn variant_to_string(value: Variant<Box<RefArg>>) -> Option<String> {
-    value.0.as_i64().and_then(|v| Some(v.to_string()))
+    value.0.as_str().and_then(|v| Some(v.to_string()))
 }
 
 

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -174,6 +174,23 @@ impl NetworkManager {
         self.property(path, NM_DEVICE_INTERFACE, "Real")
     }
 
+    pub fn activate_device(&self, path: &String) -> Result<(), String> {
+        try!(self.call_with_args(NM_SERVICE_PATH,
+                                 NM_SERVICE_INTERFACE,
+                                 "ActivateConnection",
+                                 &[MessageItem::ObjectPath("/".into()),
+                                   MessageItem::ObjectPath(path.to_string().into()),
+                                   MessageItem::ObjectPath("/".into())]));
+
+        Ok(())
+    }
+
+    pub fn disconnect_device(&self, path: &String) -> Result<(), String> {
+        try!(self.call(path, NM_DEVICE_INTERFACE, "Disconnect"));
+
+        Ok(())
+    }
+
     fn call(&self, path: &str, interface: &str, method: &str) -> Result<Message, String> {
         self.call_with_args(path, interface, method, &[])
     }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -128,6 +128,10 @@ impl NetworkManager {
            })
     }
 
+    pub fn get_connection_devices(&self, path: &String) -> Result<Vec<String>, String> {
+        self.property(path, NM_ACTIVE_INTERFACE, "Devices")
+    }
+
     pub fn delete_connection(&self, path: &String) -> Result<(), String> {
         try!(self.call(path, NM_CONNECTION_INTERFACE, "Delete"));
 

--- a/src/wifi/mod.rs
+++ b/src/wifi/mod.rs
@@ -1,3 +1,62 @@
+use manager::NetworkManager;
+use device;
+
+
+#[derive(Debug)]
+pub struct AccessPoint {
+    pub ssid: String,
+    pub strength: u32,
+    pub security: Security,
+}
+
+
+bitflags! {
+    pub flags Security: u32 {
+        const NONE         = 0b0000000,
+        const WEP          = 0b0000001,
+        const WPA          = 0b0000010,
+        const WPA2         = 0b0000100,
+        const ENTERPRISE   = 0b0001000,
+    }
+}
+
+
+bitflags! {
+    pub flags NM80211ApFlags: u32 {
+        // access point has no special capabilities
+        const AP_FLAGS_NONE           = 0x00000000,
+        // access point requires authentication and
+        const AP_FLAGS_PRIVACY        = 0x00000001,
+    }
+}
+
+
+bitflags! {
+    pub flags NM80211ApSecurityFlags: u32 {
+         // the access point has no special security requirements
+        const AP_SEC_NONE                    = 0x00000000,
+        // 40/64-bit WEP is supported for pairwise/unicast encryption
+        const AP_SEC_PAIR_WEP40              = 0x00000001,
+        // 104/128-bit WEP is supported for pairwise/unicast encryption
+        const AP_SEC_PAIR_WEP104             = 0x00000002,
+        // TKIP is supported for pairwise/unicast encryption
+        const AP_SEC_PAIR_TKIP               = 0x00000004,
+        // AES/CCMP is supported for pairwise/unicast encryption
+        const AP_SEC_PAIR_CCMP               = 0x00000008,
+        // 40/64-bit WEP is supported for group/broadcast encryption
+        const AP_SEC_GROUP_WEP40             = 0x00000010,
+        // 104/128-bit WEP is supported for group/broadcast encryption
+        const AP_SEC_GROUP_WEP104            = 0x00000020,
+        // TKIP is supported for group/broadcast encryption
+        const AP_SEC_GROUP_TKIP              = 0x00000040,
+        // AES/CCMP is supported for group/broadcast encryption
+        const AP_SEC_GROUP_CCMP              = 0x00000080,
+        // WPA/RSN Pre-Shared Key encryption is supported
+        const AP_SEC_KEY_MGMT_PSK            = 0x00000100,
+        // 802.1x authentication and key management is supported
+        const AP_SEC_KEY_MGMT_802_1X         = 0x00000200,
+    }
+}
 
 
 /// Scans for Wi-Fi access points.
@@ -5,39 +64,81 @@
 /// # Examples
 ///
 /// ```
-/// let access_points = network_manager::wifi::scan().unwrap();
+/// use network_manager::manager;
+/// use network_manager::wifi;
+/// let manager = manager::new();
+/// let access_points = wifi::scan(&manager).unwrap();
 /// println!("{:?}", access_points);
 /// ```
-pub fn scan() -> Result<Vec<AccessPoint>, String> {
-    // Scan for access points
+pub fn scan(manager: &NetworkManager) -> Result<Vec<AccessPoint>, String> {
+    let mut devices = try!(device::list(manager));
 
-    let ap1 = AccessPoint {
-        ssid: "ap1".to_string(),
-        signal: 60,
-        security: vec![Security::WEP],
-    };
+    let mut access_points = Vec::new();
 
-    let ap2 = AccessPoint {
-        ssid: "ap2".to_string(),
-        signal: 92,
-        security: vec![Security::WPA1, Security::WPA2],
-    };
+    for mut device in devices {
+        if device.device_type == device::DeviceType::WiFi {
+            let paths = try!(manager.get_device_access_points(&device.path));
 
-    Ok(vec![ap1, ap2])
+            for path in paths {
+                if let Some(access_point) = try!(get_access_point(manager, &path)) {
+                    access_points.push(access_point);
+                }
+            }
+        }
+    }
+
+    access_points.sort_by_key(|ap| ap.strength);
+    access_points.reverse();
+
+    Ok(access_points)
 }
 
 
-#[derive(Debug)]
-pub enum Security {
-    None,
-    WEP,
-    WPA1,
-    WPA2,
+fn get_access_point(manager: &NetworkManager,
+                    path: &String)
+                    -> Result<Option<AccessPoint>, String> {
+    if let Some(ssid) = manager.get_access_point_ssid(path) {
+        let strength = try!(manager.get_access_point_strength(path));
+
+        let security = try!(get_access_point_security(manager, path));
+
+        let access_point = AccessPoint {
+            ssid: ssid,
+            strength: strength,
+            security: security,
+        };
+
+        Ok(Some(access_point))
+    } else {
+        Ok(None)
+    }
 }
 
-#[derive(Debug)]
-pub struct AccessPoint {
-    ssid: String,
-    signal: u8,
-    security: Vec<Security>,
+
+fn get_access_point_security(manager: &NetworkManager, path: &String) -> Result<Security, String> {
+    let flags = try!(manager.get_access_point_flags(path));
+
+    let wpa_flags = try!(manager.get_access_point_wpa_flags(path));
+
+    let rsn_flags = try!(manager.get_access_point_rsn_flags(path));
+
+    let mut security = NONE;
+
+    if flags.contains(AP_FLAGS_PRIVACY) && wpa_flags == AP_SEC_NONE && rsn_flags == AP_SEC_NONE {
+        security |= WEP;
+    }
+
+    if wpa_flags != AP_SEC_NONE {
+        security |= WPA;
+    }
+
+    if rsn_flags != AP_SEC_NONE {
+        security |= WPA2;
+    }
+
+    if wpa_flags.contains(AP_SEC_KEY_MGMT_802_1X) || rsn_flags.contains(AP_SEC_KEY_MGMT_802_1X) {
+        security |= ENTERPRISE;
+    }
+
+    Ok(security)
 }


### PR DESCRIPTION
PR involving multiple issues: #28, #29, #7 and #1.

For Wi-Fi scan I did not use the `RequestScan` method of the `org.freedesktop.NetworkManager.Device.Wireless` interface and we may revisit this in a different issue.

The Wi-Fi card on my Ubuntu laptop cannot establish a WEP security connection (even from the OS UI), but the code is there and in theory should be working. I will need help with verifying it.

Running the example for creating a Wi-Fi connection is done with: `cargo run --example create SSID PASSWORD`.